### PR TITLE
levelDB now uses custom env

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ cmake_minimum_required(VERSION 3.5.1)
 
 project(wifs C CXX)
 
+SET(CMAKE_CXX_FLAGS  "-fno-rtti")
+
 include(../leveldb-kv-store/common.cmake)
 
 # Proto file
@@ -83,6 +85,7 @@ target_link_libraries(p2p_grpc_proto
   ${_PROTOBUF_LIBPROTOBUF})
 
 find_library(PTHREAD_LIB  NAMES pthread)
+find_library(LEVELDB_LIB  NAMES leveldb HINTS /usr/local/lib/)
 
 # client
 #add_executable(client "client.cc")
@@ -104,6 +107,11 @@ target_link_libraries(server
   ${_GRPC_GRPCPP}
   ${_PROTOBUF_LIBPROTOBUF})
 
+add_library(custom_fs "custom_fs.cc")
+target_link_libraries(custom_fs
+  ${PTHREAD_LIB}
+  ${LEVELDB_LIB})
+
 # client manual, easy for manual testing. spin up server and then client
 add_executable(client_tester "client_tester.cc")
 target_link_libraries(client_tester
@@ -111,4 +119,6 @@ target_link_libraries(client_tester
   wifs_grpc_proto
   ${_REFLECTION}
   ${_GRPC_GRPCPP}
-  ${_PROTOBUF_LIBPROTOBUF})
+  ${_PROTOBUF_LIBPROTOBUF}
+  ${LEVELDB_LIB}
+  custom_fs)

--- a/custom_fs.cc
+++ b/custom_fs.cc
@@ -1,0 +1,97 @@
+#include <iostream>
+#include "leveldb/db.h"
+#include "leveldb/env.h"
+
+using namespace leveldb;
+
+class CustomEnv : public leveldb::Env {
+    public:
+    CustomEnv(Env* t) : target_(t) {}
+    ~CustomEnv();
+
+    // Return the target to which this Env forwards all calls.
+    Env* target() const { return target_; }
+
+    // The following text is boilerplate that forwards all methods to target().
+    Status NewSequentialFile(const std::string& f, SequentialFile** r) override {
+        return target_->NewSequentialFile(f, r);
+    }
+    Status NewRandomAccessFile(const std::string& f, RandomAccessFile** r) override {
+        return target_->NewRandomAccessFile(f, r);
+    }
+    
+    Status NewWritableFile(const std::string& f, WritableFile** r) override {
+        return target_->NewWritableFile(f, r);
+    }
+    
+    Status NewAppendableFile(const std::string& f, WritableFile** r) override {
+        return target_->NewAppendableFile(f, r);
+    }
+    
+    bool FileExists(const std::string& f) override {
+        return target_->FileExists(f);
+    }
+    
+    Status GetChildren(const std::string& dir, std::vector<std::string>* r) override {
+        return target_->GetChildren(dir, r);
+    }
+    
+    Status RemoveFile(const std::string& f) override {
+        return target_->RemoveFile(f);
+    }
+    
+    Status CreateDir(const std::string& d) override {
+        return target_->CreateDir(d);
+    }
+    
+    Status RemoveDir(const std::string& d) override {
+        return target_->RemoveDir(d);
+    }
+    
+    Status GetFileSize(const std::string& f, uint64_t* s) override {
+        return target_->GetFileSize(f, s);
+    }
+    
+    Status RenameFile(const std::string& s, const std::string& t) override {
+        return target_->RenameFile(s, t);
+    }
+    
+    Status LockFile(const std::string& f, FileLock** l) override {
+        return target_->LockFile(f, l);
+    }
+    
+    Status UnlockFile(FileLock* l) override { 
+        return target_->UnlockFile(l); 
+    }
+    
+    void Schedule(void (*f)(void*), void* a) override {
+        return target_->Schedule(f, a);
+    }
+    
+    void StartThread(void (*f)(void*), void* a) override {
+        return target_->StartThread(f, a);
+    }
+    
+    Status GetTestDirectory(std::string* path) override {
+        return target_->GetTestDirectory(path);
+    }
+    
+    Status NewLogger(const std::string& fname, Logger** result) override {
+        return target_->NewLogger(fname, result);
+    }
+    
+    uint64_t NowMicros() override { 
+        return target_->NowMicros(); 
+    }
+    
+    void SleepForMicroseconds(int micros) override {
+        target_->SleepForMicroseconds(micros);
+    }
+
+    private:
+    Env* target_;
+};
+
+CustomEnv::~CustomEnv() {
+
+}


### PR DESCRIPTION
need to wrap around all zookeeper logic inside the functions defined in `custom_fs.cc`

assumes that leveldb is installed on the machine. if not,
clone leveldb repo, do a `make install` after `make -j`. will install leveldb headers and libs into `usr/local` 